### PR TITLE
Fix npm start error

### DIFF
--- a/townService/src/TestUtils.ts
+++ b/townService/src/TestUtils.ts
@@ -2,7 +2,7 @@ import { BroadcastOperator } from 'socket.io';
 
 import { mock, mockDeep, MockProxy } from 'jest-mock-extended';
 import { nanoid } from 'nanoid';
-import { SocketReservedEventsMap } from 'socket.io/dist/socket';
+import { SocketReservedEventsMap } from 'socket.io/dist/socket-types';
 import {
   EventNames,
   EventParams,


### PR DESCRIPTION
When running npm start, ran into a socket error where it could not import from socket.io/dist/socket. I changed to socket.io/dist/socket-types and I no longer have any errors running the code. If this is a device-dependent error please let me know and I will just keep the change for my individual purposes. However, I found that with this change I do not have to go through hoops and hurdles to start covey.town.